### PR TITLE
Add graphql-client on the frontend

### DIFF
--- a/components/page.tsx
+++ b/components/page.tsx
@@ -1,0 +1,9 @@
+import { Component } from 'react'
+
+class Page extends Component {
+  render() {
+    return <>{this.props.children}</>
+  }
+}
+
+export default Page

--- a/config.js
+++ b/config.js
@@ -1,1 +1,1 @@
-export const baseUrl = `http://localhost:3000`
+export const apiEndpoint = `http://localhost:3000/expenses`

--- a/lib/withData.ts
+++ b/lib/withData.ts
@@ -1,0 +1,7 @@
+import withApollo from 'next-with-apollo'
+import ApolloClient from 'apollo-boost'
+import { apiEndpoint } from '../config'
+
+const createClient = () => new ApolloClient({ uri: apiEndpoint })
+
+export default withApollo(createClient)

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,60 @@
         "@ampproject/toolbox-core": "^1.0.1"
       }
     },
+    "@apollo/react-common": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.0.1.tgz",
+      "integrity": "sha512-7SC4qqPFo/41AhaQKCRovIshKkm4JLEGXyRHi+NPsaNJyk2J/HrWREnlHVqoPzYeIyq33f1L6j/NAkKn1NOnnQ==",
+      "requires": {
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-components": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.0.1.tgz",
+      "integrity": "sha512-IQwcwv+ItW/QHUeO2zQH+CJGnqepPwwShD9H6+v1ptLvixggodr7S4KalNKXgRUVJsoPBFiVgpTMoJe3h4+Eyg==",
+      "requires": {
+        "@apollo/react-common": "^3.0.1",
+        "@apollo/react-hooks": "^3.0.1",
+        "prop-types": "^15.7.2",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-hoc": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hoc/-/react-hoc-3.0.1.tgz",
+      "integrity": "sha512-sKt0/xjr6jknJztJRWA0zX9wUY/xBq6lwyqPxrRM72hCatz/BSi1tgVv9LMHTA0aJPBK79pWXFq/EeiXW2LkVw==",
+      "requires": {
+        "@apollo/react-common": "^3.0.1",
+        "@apollo/react-components": "^3.0.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-hooks": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.0.1.tgz",
+      "integrity": "sha512-Boai/T+2z3m23Gy82m1pB+FOlrhkBJ//EIYa3pqX9sUsvgRWMKC+3NxpeHEUYqsf0qzFiM1dO4Pn9OxCFstM8g==",
+      "requires": {
+        "@apollo/react-common": "^3.0.1",
+        "@wry/equality": "^0.1.9",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@apollo/react-ssr": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/react-ssr/-/react-ssr-3.0.1.tgz",
+      "integrity": "sha512-eeAaajIH1zbMk+zigNAlEeyVH80ELrsjvRCcQxH80+THgnJx/hgkKfmhG2p1q2Djefyv6VfImAwd4xqX6/LRSA==",
+      "requires": {
+        "@apollo/react-common": "^3.0.1",
+        "@apollo/react-hooks": "^3.0.1",
+        "tslib": "^1.10.0"
+      }
+    },
     "@apollographql/apollo-tools": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.0.tgz",
@@ -1156,6 +1210,11 @@
         "@types/node": "*"
       }
     },
+    "@types/zen-observable": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -1314,6 +1373,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/context": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
+      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "requires": {
+        "@types/node": ">=6",
+        "tslib": "^1.9.3"
+      }
+    },
     "@wry/equality": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
@@ -1434,6 +1502,31 @@
         }
       }
     },
+    "apollo-boost": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/apollo-boost/-/apollo-boost-0.4.4.tgz",
+      "integrity": "sha512-ASngBvazmp9xNxXfJ2InAzfDwz65o4lswlEPrWoN35scXmCz8Nz4k3CboUXbrcN/G0IExkRf/W7o9Rg0cjEBqg==",
+      "requires": {
+        "apollo-cache": "^1.3.2",
+        "apollo-cache-inmemory": "^1.6.3",
+        "apollo-client": "^2.6.4",
+        "apollo-link": "^1.0.6",
+        "apollo-link-error": "^1.0.3",
+        "apollo-link-http": "^1.3.1",
+        "graphql-tag": "^2.4.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-cache": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.2.tgz",
+      "integrity": "sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==",
+      "requires": {
+        "apollo-utilities": "^1.3.2",
+        "tslib": "^1.9.3"
+      }
+    },
     "apollo-cache-control": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.8.1.tgz",
@@ -1453,6 +1546,33 @@
             "apollo-server-types": "0.2.1"
           }
         }
+      }
+    },
+    "apollo-cache-inmemory": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.3.tgz",
+      "integrity": "sha512-S4B/zQNSuYc0M/1Wq8dJDTIO9yRgU0ZwDGnmlqxGGmFombOZb9mLjylewSfQKmjNpciZ7iUIBbJ0mHlPJTzdXg==",
+      "requires": {
+        "apollo-cache": "^1.3.2",
+        "apollo-utilities": "^1.3.2",
+        "optimism": "^0.10.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-client": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.4.tgz",
+      "integrity": "sha512-oWOwEOxQ9neHHVZrQhHDbI6bIibp9SHgxaLRVPoGvOFy7OH5XUykZE7hBQAVxq99tQjBzgytaZffQkeWo1B4VQ==",
+      "requires": {
+        "@types/zen-observable": "^0.8.0",
+        "apollo-cache": "1.3.2",
+        "apollo-link": "^1.0.0",
+        "apollo-utilities": "1.3.2",
+        "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     },
     "apollo-datasource": {
@@ -1533,6 +1653,36 @@
         "ts-invariant": "^0.4.0",
         "tslib": "^1.9.3",
         "zen-observable-ts": "^0.8.19"
+      }
+    },
+    "apollo-link-error": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.11.tgz",
+      "integrity": "sha512-442DNqn3CNRikDaenMMkoDmCRmkoUx/XyUMlRTZBEFdTw3FYPQLsmDO3hzzC4doY5/BHcn9/jdYh9EeLx4HPsA==",
+      "requires": {
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-link-http": {
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.15.tgz",
+      "integrity": "sha512-epZFhCKDjD7+oNTVK3P39pqWGn4LEhShAoA1Q9e2tDrBjItNfviiE33RmcLcCURDYyW5JA6SMgdODNI4Is8tvQ==",
+      "requires": {
+        "apollo-link": "^1.2.12",
+        "apollo-link-http-common": "^0.2.14",
+        "tslib": "^1.9.3"
+      }
+    },
+    "apollo-link-http-common": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz",
+      "integrity": "sha512-v6mRU1oN6XuX8beVIRB6OpF4q1ULhSnmy7ScnHnuo1qV6GaFmDcbdvXqxIkAV1Q8SQCo2lsv4HeqJOWhFfApOg==",
+      "requires": {
+        "apollo-link": "^1.2.12",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-server": {
@@ -4383,6 +4533,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
@@ -5231,6 +5389,14 @@
         "url": "0.11.0"
       }
     },
+    "next-with-apollo": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/next-with-apollo/-/next-with-apollo-4.2.0.tgz",
+      "integrity": "sha512-Z655t9uudwlVgwkGUSjsSHfOlzOTnOp0CUihiY+vV1TD2QQyRB2e3mn/sWBRZ3HjcZjkU89Exxlah1AOni07JA==",
+      "requires": {
+        "isomorphic-unfetch": "^3.0.0"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -5441,6 +5607,14 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "optimism": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.2.tgz",
+      "integrity": "sha512-zPfBIxFFWMmQboM9+Z4MSJqc1PXp82v1PFq/GfQaufI69mHKlup7ykGNnfuGIGssXJQkmhSodQ/k9EWwjd8O8A==",
+      "requires": {
+        "@wry/context": "^0.4.0"
       }
     },
     "os-browserify": {
@@ -5918,6 +6092,18 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-apollo": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-3.0.1.tgz",
+      "integrity": "sha512-2hsSYBfxPqPquS8CupWq+U+6XuDfr/Rr1ssXwfOTYe5gCyTthdUqafIm+pyStur9X2W4ZNQMFyjVicsPNq2tnA==",
+      "requires": {
+        "@apollo/react-common": "^3.0.1",
+        "@apollo/react-components": "^3.0.1",
+        "@apollo/react-hoc": "^3.0.1",
+        "@apollo/react-hooks": "^3.0.1",
+        "@apollo/react-ssr": "^3.0.1"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "Arshad Khan<arshdkhn1@gmail.com>",
   "license": "ISC",
   "dependencies": {
+    "apollo-boost": "^0.4.4",
     "apollo-server": "^2.9.0",
     "debug": "^4.1.1",
     "dotenv": "^8.1.0",
@@ -30,7 +31,9 @@
     "isomorphic-unfetch": "^3.0.0",
     "morgan": "^1.9.1",
     "next": "^9.0.5",
+    "next-with-apollo": "^4.2.0",
     "react": "^16.9.0",
+    "react-apollo": "^3.0.1",
     "react-dom": "^16.9.0"
   },
   "devDependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,42 @@
+import App from 'next/app'
+import { NextComponentType, NextPageContext } from 'next'
+import { ApolloProvider } from 'react-apollo'
+import ApolloClient from 'apollo-client'
+import Page from '../components/page'
+import withData from '../lib/withData'
+
+interface PageProps {
+  [index: string]: any;
+}
+
+class MyApp extends App<{
+  apollo: ApolloClient<{}>,
+  Component: NextComponentType,
+  ctx: NextPageContext
+}> {
+  render() {
+    const { Component, apollo, pageProps } = this.props
+
+    return (
+      <ApolloProvider client={apollo}>
+        <Page>
+          <Component {...pageProps} />
+        </Page>
+      </ApolloProvider>
+    )
+  }
+}
+
+MyApp.getInitialProps = async ({ Component, ctx }) => {
+  let pageProps: PageProps = {}
+
+  // makes sure all the queries and mutations on the page are fired up before component is rendered
+  if (Component.getInitialProps) {
+    pageProps = await Component.getInitialProps(ctx)
+  }
+  // this exposes the query to the user
+  pageProps.query = ctx.query
+  return { pageProps }
+}
+
+export default withData(MyApp)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,19 @@
-import { NextPage } from 'next'
 import Link from 'next/link'
-import fetch from 'isomorphic-unfetch'
-import { baseUrl } from '../config'
+import gql from 'graphql-tag'
+import { NextPage } from 'next'
+import { Query, QueryResult } from 'react-apollo'
+
+const ALL_EXPENSES_QUERY = gql`
+  query ALL_EXPENSES_QUERY($limit: Int, $offset: Int) {
+    expenses(limit: $limit, offset: $offset) {
+      data {
+        id
+        date
+      }
+      total
+    }
+  }
+`
 
 const Home: NextPage = () => (
   <>
@@ -9,16 +21,13 @@ const Home: NextPage = () => (
     <Link href="/item">
       <a>/item</a>
     </Link>
+    <Query query={ALL_EXPENSES_QUERY} variables={{ limit: 3, offset: 0 }}>
+      {({ data, error, loading }: QueryResult) => {
+        console.log(data, error, loading)
+        return <p>I am child of query</p>
+      }}
+    </Query>
   </>
 )
-
-// Home.getInitialProps = async ({ req }) => {
-//   const res = await fetch(`${baseUrl}/expenses/5b995dff2e3cb74644948a66ff`)
-//   const data = await res.json()
-
-//   return {
-//     data
-//   }
-// }
 
 export default Home

--- a/server/app.ts
+++ b/server/app.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as logger from 'morgan'
 import * as bodyParser from 'body-parser'
 
-import { graphqlExpress, graphiqlExpress } from 'graphql-server-express'
+import { graphqlExpress } from 'graphql-server-express'
 import { makeExecutableSchema } from 'graphql-tools'
 
 import { typeDefs } from './data/schema'
@@ -36,11 +36,6 @@ app.prepare().then(() => {
   server.use('/receipts', express.static(path.join(__dirname, 'receipts')))
 
   server.use('/expenses', bodyParser.json(), graphqlExpress({ schema: executableSchema }))
-
-  // don't expose graphiql in production
-  if(dev) {
-    server.use('/graphiql', graphiqlExpress({ endpointURL: '/expenses' }))
-  }
 
   // next.js handling rest of the get requests
   server.get('*', (req, res) => handle(req, res))

--- a/server/data/query.ts
+++ b/server/data/query.ts
@@ -1,12 +1,12 @@
 import { expenses } from './expenses'
 
 export const Query = {
-  expenses: (_, { limit = 25, offset = 0}) => {
+  expenses: (_, { limit = 25, offset = 0 }) => {
     limit = Math.round(limit)
     offset = Math.round(offset)
 
     return {
-      expenses: expenses
+      data: expenses
         .sort((a, b) => {
           const valA = Date.parse(a.date)
           const valB = Date.parse(b.date)
@@ -23,7 +23,5 @@ export const Query = {
       total: expenses.length
     }
   },
-  expense: (_, { id }) => expenses.find((expense) => expense.id === id),
-  receipts: () => expenses.map(expense => expense.receipts)
+  expense: (_, { id }) => expenses.find((expense) => expense.id === id)
 }
-

--- a/server/data/schema.ts
+++ b/server/data/schema.ts
@@ -29,14 +29,13 @@ export const typeDefs = gql`
   }
 
   type AllExpensesResponse {
-    expenses: [Expense]!
+    data: [Expense]!
     total: Int
   }
 
   type Query {
     expenses(limit: Int, offset: Int): AllExpensesResponse!
     expense(id: ID!): Expense!
-    receipts: [Receipt]!
   }
 
   type Mutation {


### PR DESCRIPTION
Using apollo-boost and apollo-client to manage the front-end. Using render props in Query and Mutation components, we can declaratively get the query results.